### PR TITLE
🐛Fix: 체크아웃 수정

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -15,7 +15,7 @@ pipeline {
         stage('Checkout') {
             steps {
                 checkout([$class: 'GitSCM',
-                    branches: [[name: 'develop']],
+                    branches: [[name: '**']],
                     extensions: [[$class: 'CloneOption', 
                         noTags: false, 
                         shallow: false, 


### PR DESCRIPTION
Git 태그는 기본적으로 브랜치가 아니기 때문에, name: 'develop'처럼 특정 브랜치만 명시하면 태그를 체크아웃하지 못함
**를 사용하여 모든 참조(브랜치와 태그 포함)를 체크아웃하도록 수정