### PR TITLE
🐛Fix: 조건 변경

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -14,7 +14,9 @@ pipeline {
     stages {
         stage('Checkout') {
             when {
-                buildingTag()  
+                expression { 
+                    return env.GIT_BRANCH.startsWith('origin/tags/release-')
+                }
             }
             steps {
                 checkout([$class: 'GitSCM',
@@ -32,7 +34,9 @@ pipeline {
 
         stage('Build and Push Docker Images') {
             when {
-                buildingTag()  
+                expression { 
+                    return env.GIT_BRANCH.startsWith('origin/tags/release-')
+                }
             }
             steps {
                 script {
@@ -47,7 +51,9 @@ pipeline {
 
         stage('Deploy to EC2') {
             when {
-                buildingTag()  
+                expression { 
+                    return env.GIT_BRANCH.startsWith('origin/tags/release-')
+                }
             }
             steps {
                 sshagent(credentials: ['ec2-ssh-key']) { 


### PR DESCRIPTION
조건 설명
env.GIT_BRANCH는 Jenkins가 현재 체크아웃한 브랜치나 태그의 전체 경로를 담고 있는 환경변수입니다
startsWith('origin/tags/release-')는 브랜치 이름이 'origin/tags/release-'로 시작하는지 확인합니다
예를 들어 'origin/tags/release-v1.0'이면 조건이 참이 됩니다
return 문의 역할
expression 블록 내에서는 반드시 boolean 값(true/false)을 반환해야 합니다
return은 이 boolean 값을 명시적으로 반환하는 역할을 합니다
startsWith()는 boolean을 반환하므로, 이 값이 true일 때 해당 스테이지가 실행됩니다
실제 동작
release-* 태그를 푸시하면 GIT_BRANCH가 'origin/tags/release-*' 형태가 됩니다
이때 startsWith() 조건이 true가 되어 스테이지가 실행됩니다
일반 브랜치 푸시의 경우 false가 되어 스테이지가 건너뛰게 됩니다