### PR TITLE
Fix/jenkins

### DIFF
--- a/test.py
+++ b/test.py
@@ -1,1 +1,0 @@
-# jenkin cd test


### PR DESCRIPTION
git rev-parse --abbrev-ref HEAD
현재 체크아웃된 브랜치나 태그의 이름을 가져옵니다.
if [[ $BRANCH_NAME == *"tags/"* ]]
브랜치 이름에 "tags/"라는 문자열이 포함되어 있는지 확인합니다.
Git에서 태그는 보통 "refs/tags/" 형식으로 저장되기 때문입니다.
returnStatus: true와 == 0
스크립트가 성공(exit 0)하면 태그이고, 실패(exit 1)하면 일반 브랜치입니다.
if (!isTag)
태그가 아닌 경우 빌드를 중단하고 'Not a tag push' 메시지를 출력합니다.
currentBuild.result = 'NOT_BUILT'로 빌드 결과를 설정합니다.